### PR TITLE
chore(yarn): pin @types/node to 10.11.0 for fixing builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@types/jasmine": "~2.8.8",
     "@types/jasminewd2": "~2.0.3",
     "@types/marked": "^0.4.0",
-    "@types/node": "~10.11.0",
+    "@types/node": "10.11.0",
     "@types/uuid": "^3.4.3",
     "codelyzer": "~4.4.4",
     "husky": "^1.0.0",


### PR DESCRIPTION
Fixes #11 